### PR TITLE
feat(publish): implement feature artifact packaging and release upload

### DIFF
--- a/.github/workflows/devcontainer-features.yml
+++ b/.github/workflows/devcontainer-features.yml
@@ -61,19 +61,21 @@ jobs:
           find features -name feature.json | while read file; do
             echo "Checking $file"
             jq empty "$file"
-
-      - name: Log published features
-        run: |
-          echo "Listing features included in this release:"
-          find features -maxdepth 1 -mindepth 1 -type d | while read feature_dir; do
-            feature_name=$(basename "$feature_dir")
-            feature_version=$(jq -r '.version' "$feature_dir/feature.json")
-            echo "Feature: $feature_name, Version: $feature_version"
           done
 
-      # Placeholder for actual publishing (future)
-      # - name: Publish to Feature Registry
-      #   run: |
-      #     echo "Publishing features to registry..."
-      #     your-publish-command-here
+      - name: Package features into zip files
+        run: |
+          echo "Packaging features..."
+          mkdir -p artifacts
+          find features -maxdepth 1 -mindepth 1 -type d | while read feature_dir; do
+            feature_name=$(basename "$feature_dir")
+            echo "Zipping $feature_name..."
+            zip -r "artifacts/${feature_name}.zip" "$feature_dir"
+          done
 
+      - name: Upload feature artifacts to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR enhances the publish step to properly package and upload features after a release.
Each feature under the `features/` directory is zipped individually and attached as a Release asset.
This makes it easier to distribute, download, and manage features independently.

- Validate feature.json files
- Package each feature into a zip file
- Upload artifacts to GitHub Release using softprops/action-gh-release
- Ensure compatibility with GitHub token permissions

This completes the end-to-end automation for validating, releasing, and publishing DevContainer features.